### PR TITLE
Add initialization of the service client node.

### DIFF
--- a/ros_start/scritps/service_client.py
+++ b/ros_start/scritps/service_client.py
@@ -3,14 +3,20 @@
 import rospy
 from std_srvs.srv import Empty
 
-def service_client():
+def call_service():
     rospy.loginfo('waiting service')
     rospy.wait_for_service('call_me')
+
     try:
         service = rospy.ServiceProxy('call_me', Empty)
         response = service()
     except rospy.ServiceException, e:
         print "Service call failed: %s" % e
+
+def service_client():
+    rospy.init_node('service_client')
+    call_service()
+    rospy.spin()
 
 if __name__ == "__main__":
     service_client()


### PR DESCRIPTION
Without initializing the client node, the message here can not be displayed:
https://github.com/OTL/ros_book_programs/blob/master/ros_start/scritps/service_client.py#L7

Also, adding rospy.spin() prevents unnecessary error messages when terminated with ctrl+c